### PR TITLE
add basic tests for saved outfits view

### DIFF
--- a/WearaboutsExpo/_tests_/saved-outfits.test.tsx
+++ b/WearaboutsExpo/_tests_/saved-outfits.test.tsx
@@ -3,11 +3,32 @@ import { render, screen } from '@testing-library/react-native';
 import SavedOutfits from '../app/(tabs)/saved-outfits';
 
 describe('SavedOutfits', () => {
-  it('renders the SavedOutfits component', () => {
+
+  // Test 1: Ensure the main title renders
+  it('renders the Saved Outfits title', () => {
     render(<SavedOutfits />);
-    
-    // Example: check for a text that exists in your component
-    const title = screen.getByText(/Saved Outfits/i); 
+    const title = screen.getByText(/Saved Outfits/i);
     expect(title).toBeTruthy();
   });
+
+  // Test 2: Ensure at least one category is displayed
+  it('renders at least one outfit category', () => {
+    render(<SavedOutfits />);
+    const category = screen.queryByText(/Casual/i); // replace with a real category if needed
+    expect(category).not.toBeNull();
+  });
+
+  // Test 3: Ensure at least one outfit item is displayed
+  it('renders at least one outfit item', () => {
+    render(<SavedOutfits />);
+    const outfitItems = screen.getAllByText(/Outfit/i);
+    expect(outfitItems.length).toBeGreaterThan(0);
+  });
+
+  // Test 4: Render the component without crashing
+  it('renders without crashing', () => {
+    const { root } = render(<SavedOutfits />);
+    expect(root).toBeTruthy();
+  });
+
 });


### PR DESCRIPTION
adds a couple jest unit tests for the saved outfits view. ran `npm run test` and passed all unit tests: 
<img width="492" height="238" alt="image" src="https://github.com/user-attachments/assets/918c0ac5-1ac4-4a2d-8a69-f6604f79f408" />
