### PR TITLE
Disabling multiple images upload at once

### DIFF
--- a/WearaboutsExpo/_tests_/add-clothes.test.tsx
+++ b/WearaboutsExpo/_tests_/add-clothes.test.tsx
@@ -66,7 +66,7 @@ describe("AddClothesScreen", () => {
 
     // Pick image
     await act(async () => {
-      fireEvent.press(screen.getByText("Tap to upload images"));
+      fireEvent.press(screen.getByText("Tap to upload an image"));
       await Promise.resolve();
     });
 
@@ -90,7 +90,7 @@ describe("AddClothesScreen", () => {
 
     // Pick image
     await act(async () => {
-      fireEvent.press(getByText("Tap to upload images"));
+      fireEvent.press(getByText("Tap to upload an image"));
       await Promise.resolve();
     });
 

--- a/WearaboutsExpo/app/(tabs)/add-clothes.tsx
+++ b/WearaboutsExpo/app/(tabs)/add-clothes.tsx
@@ -30,7 +30,7 @@ export default function AddClothesScreen() {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: "images",
       allowsEditing: false,
-      allowsMultipleSelection: true,
+      allowsMultipleSelection: false,
       quality: 1,
     });
 
@@ -102,7 +102,7 @@ export default function AddClothesScreen() {
           className="w-full mb-4 rounded-2xl bg-brandPink justify-center items-center p-8 shadow-sm shadow-black/10 border-white border-dashed border-2"
           onPress={pickImages}
         >
-          <Text className="text-lg font-bold text-textGreen">Tap to upload images</Text>
+          <Text className="text-lg font-bold text-textGreen">Tap to upload an image</Text>
         </TouchableOpacity>
 
         {/* Item Name Input */}


### PR DESCRIPTION
This ensures that users are only able to upload one image at a time (this helps us get rid of any issues with selecting multiple different categories for multiple images and stuff like that).