### PR TITLE
Fix refresh issue for saved outfit view

### DIFF
--- a/WearaboutsExpo/app/(tabs)/outfit-closet/index.tsx
+++ b/WearaboutsExpo/app/(tabs)/outfit-closet/index.tsx
@@ -74,6 +74,15 @@ export default function SavedOutfitsScreen() {
             ) : null
           }
           contentContainerStyle={{ paddingHorizontal: 8, paddingBottom: 16 }}
+          ListEmptyComponent={
+            <View style={{ flex: 1, justifyContent: "center", alignItems: "center", paddingVertical: 200 }}>
+              <Text style={{ fontSize: 20, color: "gray", textAlign: "center" }}>
+                No outfits yet! {"\n"}
+                
+                Pull down to refresh.
+              </Text>
+            </View>
+          }
         />
       </View>
     </GradientBackground>


### PR DESCRIPTION
Ensures that even when there were no outfits saved prior to generating outfits, the user would be able to refresh their saved outfit screen. This is what it looks like now when there are no saved outfits:
<img width="359" height="781" alt="image" src="https://github.com/user-attachments/assets/22c6c32c-2064-4bc4-9376-892884a86538" />
